### PR TITLE
Don't throw EntityNotFoundException if previewing message Fixes #7

### DIFF
--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -601,8 +601,18 @@ class EED_Wait_Lists extends EED_Module
      */
     public static function wait_list_checkout_url_query_args(array $query_args, EE_Registration $registration)
     {
+        try {
+            $transaction = $registration->transaction();
+        } catch (EntityNotFoundException $exception) {
+            if (! (isset($_REQUEST['action']) && $_REQUEST['action'] === 'preview_message')) {
+                throw $exception;
+            }
+            $transaction = null;
+        }
         // if the attendee info step has not been completed, then always go to that step
-        if ($registration->transaction()->reg_step_completed('attendee_information') !== true) {
+        if ($transaction instanceof EE_Transaction
+            && $transaction->reg_step_completed('attendee_information') !== true
+        ) {
             $query_args['step'] = 'attendee_information';
             // and also remove the 'revisit' and 'clear_session' parameters
             unset($query_args['revisit'], $query_args['clear_session']);

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -306,8 +306,8 @@ class EED_Wait_Lists extends EED_Module
      */
     public static function process_wait_list_form_for_event()
     {
-        /** @var EE_Request $request */
-        $request         = LoaderFactory::getLoader()->getShared('EE_Request');
+        /** @var EventEspresso\core\services\request\RequestInterface $request */
+        $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface');
         $event_id        = absint($request->getMatch('event-wait-list-*[event_id]', 0));
         $redirect_params = array();
         try {
@@ -604,7 +604,9 @@ class EED_Wait_Lists extends EED_Module
         try {
             $transaction = $registration->transaction();
         } catch (EntityNotFoundException $exception) {
-            if (! (isset($_REQUEST['action']) && $_REQUEST['action'] === 'preview_message')) {
+            /** @var EventEspresso\core\services\request\RequestInterface $request */
+            $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface');
+            if ($request->getRequestParam('action') !== 'preview_message') {
                 throw $exception;
             }
             $transaction = null;


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #7
Attempting to preview a receipt that uses the `EVENT_LIST` message shortcode results in an exception being thrown because the messages system attempts to use a transaction with an ID of 999999 to populate the required data, but this transaction does not actually exist.

## How has this been tested
confirmed in browser