### PR TITLE
Just redirect to the referring url

### DIFF
--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -319,11 +319,14 @@ class EED_Wait_Lists extends EED_Module
         if (defined('DOING_AJAX') && DOING_AJAX) {
             exit();
         }
-        $referrer = $event_id === 0
-            ? filter_input(INPUT_SERVER, 'HTTP_REFERER')
-            : get_permalink($event_id);
-        $referrer = add_query_arg($redirect_params, trailingslashit($referrer));
-        EEH_URL::safeRedirectAndExit($referrer);
+        EEH_URL::safeRedirectAndExit(
+            add_query_arg(
+                $redirect_params,
+                trailingslashit(
+                    filter_input(INPUT_SERVER, 'HTTP_REFERER')
+                )
+            )
+        );
     }
 
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Currently, when you submit the wait list form, it redirects you to the single event CPT for the related event. This is fine if you're already on the single event CPT, but can be confusing if you've submitted the form on a post or page (via the Ticket Selector shortcode) or if the form appeared on the events CPT archive. 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Activate the ticket selector for Event Archives, then set up a sold out event so it's ready to accept wait list requests
- [x] Go to Event archives and complete + submit the wait list form
- [x] Expected result is you'll land on the Event archives
- [x] Go to edit the sold out event, and grab the ticket selector shortcode
- [x] Add the ticket selector shortcode to a page, publish
- [x] Test the wait list form on the published page
- [x] Expected result is you'll land on the page with the shortcode

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
