### PR TITLE
Remove Google Plus from default templates

### DIFF
--- a/views/messages/templates/email_registration_added_to_waitlist_content.template.php
+++ b/views/messages/templates/email_registration_added_to_waitlist_content.template.php
@@ -61,10 +61,9 @@
                             <tbody>
                             <tr>
                                 <td>
-                                    <h5><?php _e('Connect with Us:', 'event_espresso'); ?></h5>
-                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]"><?php _e('Facebook', 'event_espresso'); ?></a>
-                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]"><?php _e('Twitter', 'event_espresso'); ?></a>
-                                    <a class="soc-btn gp" href="[CO_GOOGLE_URL]"><?php _e('Google+', 'event_espresso'); ?></a>
+                                    <h5><?php esc_html_e('Connect with Us:', 'event_espresso'); ?></h5>
+                                    <a class="soc-btn fb" href="[CO_FACEBOOK_URL]"><?php esc_html_e('Facebook', 'event_espresso'); ?></a>
+                                    <a class="soc-btn tw" href="[CO_TWITTER_URL]"><?php esc_html_e('Twitter', 'event_espresso'); ?></a>
                                 </td>
                             </tr>
                             </tbody>
@@ -74,9 +73,9 @@
                             <tbody>
                             <tr>
                                 <td>
-                                    <h5><?php _e('Contact Info:', 'event_espresso'); ?></h5>
-                                    <?php _e('Phone:', 'event_espresso'); ?> <strong>[CO_PHONE]</strong>
-                                    <?php _e('Email:', 'event_espresso'); ?>
+                                    <h5><?php esc_html_e('Contact Info:', 'event_espresso'); ?></h5>
+                                    <?php esc_html_e('Phone:', 'event_espresso'); ?> <strong>[CO_PHONE]</strong>
+                                    <?php esc_html_e('Email:', 'event_espresso'); ?>
                                     <strong><a href="mailto:[CO_EMAIL]" target="_blank">[CO_EMAIL]</a></strong>
                                 </td>
                             </tr>

--- a/views/messages/templates/email_registration_demoted_to_waitlist_content.template.php
+++ b/views/messages/templates/email_registration_demoted_to_waitlist_content.template.php
@@ -100,9 +100,6 @@
                                     <a class="soc-btn tw" href="[CO_TWITTER_URL]">
                                         <?php esc_html_e('Twitter', 'event_espresso'); ?>
                                     </a>
-                                    <a class="soc-btn gp" href="[CO_GOOGLE_URL]">
-                                        <?php esc_html_e('Google+', 'event_espresso'); ?>
-                                    </a>
                                 </td>
                             </tr>
                             </tbody>

--- a/views/messages/templates/email_waitlist_can_register_content.template.php
+++ b/views/messages/templates/email_waitlist_can_register_content.template.php
@@ -101,9 +101,6 @@
                                     <a class="soc-btn tw" href="[CO_TWITTER_URL]">
                                         <?php esc_html_e('Twitter', 'event_espresso'); ?>
                                     </a>
-                                    <a class="soc-btn gp" href="[CO_GOOGLE_URL]">
-                                        <?php esc_html_e('Google+', 'event_espresso'); ?>
-                                    </a>
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expedite acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The problem is Google Plus is no more, so no need to include mention of Google Plus in the default templates.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Reset Wait list-related templates (3 of them) and check the templates. The default template contents will no longer include mention of Google Plus.
**Important Note:** This PR does not remove the ability to parse the Google Plus shortcode, we'll leave that for now. 


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
