### PR TITLE
Fix fatals on test sends of message types including recipient link (fixes #15)

### DIFF
--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -609,7 +609,8 @@ class EED_Wait_Lists extends EED_Module
         } catch (EntityNotFoundException $exception) {
             /** @var EventEspresso\core\services\request\RequestInterface $request */
             $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface');
-            if ($request->getRequestParam('action') !== 'preview_message') {
+            $action = $request->getRequestParam('action');
+            if ($action !== 'preview_message' && $action !== 'update_message_template') {
                 throw $exception;
             }
             $transaction = null;


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

When a test send is occurring the `update_message_template` action is in the request, so this is a reliable mechanism for whether to continue throwing the error or not.

## How has this been tested
Copied reproduction steps from #15:

1. Activate Wait List add-on (master)
2. Go to edit the core Registration Approved template > Registrant context
3. Add the `[RECIPIENT_EDIT_REGISTRATION_LINK]` shortcode to the main content section
4. Save and try sending a Test message 

* [x] verify that there are no fatal errors when sending a test send.

The steps above should apply for ANY field in any message that accepts the `[RECIPIENT_EDIT_REGISTRATION_LINK]` shortcode.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
