### PR TITLE
Set the user_id (which is the event author id) on the EE_Messages_Addressee

### DIFF
--- a/domain/entities/EE_Waitlist_Message_Type_Base.class.php
+++ b/domain/entities/EE_Waitlist_Message_Type_Base.class.php
@@ -155,7 +155,7 @@ class EE_Waitlist_Message_Type_Base extends EE_message_type
         }
 
         $related_event = reset($this->_data->events);
-        $data_for_addressee['user_id']   = $related_event['event'] instanceof EE_Event ? $related_event['event']->get('EVT_wp_user') : null;
+        $data_for_addressee['user_id']   = $related_event['event'] instanceof EE_Event ? $related_event['event']->get('EVT_wp_user') : 0;
         $data_for_addressee['events']    = $this->_data->events;
         $data_for_addressee['reg_obj']   = $this->_data->reg_obj;
         $data_for_addressee['attendees'] = $this->_data->attendees;

--- a/domain/entities/EE_Waitlist_Message_Type_Base.class.php
+++ b/domain/entities/EE_Waitlist_Message_Type_Base.class.php
@@ -154,6 +154,8 @@ class EE_Waitlist_Message_Type_Base extends EE_message_type
             $data_for_addressee[ $item ] = $value;
         }
 
+        $related_event = reset($this->_data->events);
+        $data_for_addressee['user_id']   = $related_event['event'] instanceof EE_Event ? $related_event['event']->get('EVT_wp_user') : null;
         $data_for_addressee['events']    = $this->_data->events;
         $data_for_addressee['reg_obj']   = $this->_data->reg_obj;
         $data_for_addressee['attendees'] = $this->_data->attendees;


### PR DESCRIPTION
This pull request sets up the user_id on the EE_Messages_Addressee using the first event from the event set up on the message type, there should only be one event for this message type by the `_data->events` is set up to be an associative array with the EVT_ID as the key and then various bits of info, see [HERE](https://github.com/eventespresso/event-espresso-core/blob/master/core/libraries/messages/data_class/EE_Messages_incoming_data.core.php#L432-L442)

## Problem this Pull Request solves
Allows the use of `EVENT_AUTHOR_` based shortcodes within the waitlist messages.

## How has this been tested
Add `[EVENT_AUTHOR_EMAIL]` to any of the waitlist messages main content section, previousy it would parse to nothing, in this branch it will output the email of the event author.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
