### PR TITLE
Don't set free tickets to be automatically approved.

### DIFF
--- a/domain/services/commands/PromoteWaitListRegistrantsCommandHandler.php
+++ b/domain/services/commands/PromoteWaitListRegistrantsCommandHandler.php
@@ -222,12 +222,6 @@ class PromoteWaitListRegistrantsCommandHandler extends WaitListCommandHandler
                 continue;
             }
             $new_reg_status = $event->default_registration_status();
-            // if default reg status is NOT RNA (Not Approved) and ALL of the regs on the TXN are free
-            // then set the reg status to Approved, otherwise just use the default
-            $new_reg_status = $new_reg_status !== EEM_Registration::status_id_not_approved
-                              && $registration->transaction()->is_free()
-                ? EEM_Registration::status_id_approved
-                : $new_reg_status;
             $registration->set_status(
                 $new_reg_status,
                 false,

--- a/tests/testcases/PromoteWaitListRegistrantsCommandHandlerTest.php
+++ b/tests/testcases/PromoteWaitListRegistrantsCommandHandlerTest.php
@@ -79,7 +79,7 @@ class PromoteWaitListRegistrantsCommandHandlerTest extends WaitListUnitTestCase
             array(
                 0,
                 EEM_Registration::status_id_pending_payment,
-                EEM_Registration::status_id_approved,
+                EEM_Registration::status_id_pending_payment,
             ),
             array(
                 0,


### PR DESCRIPTION
In short if you have a free ticket and users sign up to be on the waitlist, if a space becomes available and their registration is Approved they don't get an email stating they have been approved.

The 'Registration Promoted From Wait List Notification' is sent but the registration is already approved so even when the user finalizes the registration from the link in the email, no email is triggered.

For now I think its best if we set the add-on to treat all waitlist registrations the same and just have them set to pending payment (or whatever DRS they have), if the user then uses the link in the email they can finalize the reg and receive the reg approved email.

This change is basically just removing a check for a free txn, everything else is core waitlist behaviour.

## How has this been tested
Create an event with a datetime/ticket limit of 1 with a free ticket and register onto it (make sure it set up to accept waitlist registrations)

Add a least 1 waitlist registration to the event.

Now cancel the first 'Approved' registration and the waitlist registration should be set to pending payment (assuming you have that set as the DRS).

View the message activity table and open up the promotion email, click the link and finalize, you should now have an Approved registration.... check the Reg Approved emails send.

Note in master when you cancelled the approved registration is would automatically set the next waitlist reg to Approved and send them the email to finalize... which then basically did nothing.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
