### PR TITLE
Fix issue with reg URL when multiple wait list regs become available

### DIFF
--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -648,13 +648,6 @@ class EED_Wait_Lists extends EED_Module
             ),
             $registration
         );
-        if (WP_DEBUG) {
-            EEM_Change_Log::instance()->log(
-                Domain::LOG_TYPE_WAIT_LIST,
-                "Wait List Checkout URL: {$checkout_url}",
-                $registration
-            );
-        }
         return $checkout_url;
     }
 

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -641,7 +641,7 @@ class EED_Wait_Lists extends EED_Module
             'FHEE__EED_Wait_Lists__wait_list_checkout_url',
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->reg_url_link(),
+                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 EE_Registry::instance()->CFG->core->reg_page_url()

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -641,20 +641,13 @@ class EED_Wait_Lists extends EED_Module
             'FHEE__EED_Wait_Lists__wait_list_checkout_url',
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->reg_url_link(),
+                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 EE_Registry::instance()->CFG->core->reg_page_url()
             ),
             $registration
         );
-        if (WP_DEBUG) {
-            EEM_Change_Log::instance()->log(
-                Domain::LOG_TYPE_WAIT_LIST,
-                "Wait List Checkout URL: {$checkout_url}",
-                $registration
-            );
-        }
         return $checkout_url;
     }
 

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -641,13 +641,20 @@ class EED_Wait_Lists extends EED_Module
             'FHEE__EED_Wait_Lists__wait_list_checkout_url',
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
+                    'e_reg_url_link' => $registration->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 EE_Registry::instance()->CFG->core->reg_page_url()
             ),
             $registration
         );
+        if (WP_DEBUG) {
+            EEM_Change_Log::instance()->log(
+                Domain::LOG_TYPE_WAIT_LIST,
+                "Wait List Checkout URL: {$checkout_url}",
+                $registration
+            );
+        }
         return $checkout_url;
     }
 

--- a/domain/services/modules/EED_Wait_Lists_Messages.module.php
+++ b/domain/services/modules/EED_Wait_Lists_Messages.module.php
@@ -90,10 +90,6 @@ class EED_Wait_Lists_Messages extends EED_Messages
         EE_Event $event,
         ContextInterface $context = null
     ) {
-        // only trigger if it's a primary registrant
-        if (! $registration->is_primary_registrant()) {
-            return;
-        }
         // check context before triggering.
         if ($context instanceof ContextInterface
             && (

--- a/domain/services/modules/EED_Wait_Lists_Messages.module.php
+++ b/domain/services/modules/EED_Wait_Lists_Messages.module.php
@@ -90,6 +90,10 @@ class EED_Wait_Lists_Messages extends EED_Messages
         EE_Event $event,
         ContextInterface $context = null
     ) {
+        // only trigger if it's a primary registrant
+        if (! $registration->is_primary_registrant()) {
+            return;
+        }
         // check context before triggering.
         if ($context instanceof ContextInterface
             && (

--- a/tests/testcases/EED_Wait_List_Test.php
+++ b/tests/testcases/EED_Wait_List_Test.php
@@ -36,7 +36,7 @@ class EED_Wait_List_Test extends EE_UnitTestCase
         PHPUnit_Framework_TestCase::assertEquals(
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
+                    'e_reg_url_link' => $registration->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 $reg_page_url

--- a/tests/testcases/EED_Wait_List_Test.php
+++ b/tests/testcases/EED_Wait_List_Test.php
@@ -26,7 +26,12 @@ class EED_Wait_List_Test extends EE_UnitTestCase
     public function test_wait_list_checkout_url()
     {
         /** @var EE_Registration $registration */
-        $registration = $this->new_model_obj_with_dependencies('Registration');
+        $registration = $this->new_model_obj_with_dependencies(
+            'Registration',
+            array(
+                'REG_count' => 1
+            )
+        );
         PHPUnit_Framework_TestCase::assertInstanceOf(
             'EE_Registration',
             $registration
@@ -36,7 +41,7 @@ class EED_Wait_List_Test extends EE_UnitTestCase
         PHPUnit_Framework_TestCase::assertEquals(
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->reg_url_link(),
+                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 $reg_page_url

--- a/tests/testcases/EED_Wait_List_Test.php
+++ b/tests/testcases/EED_Wait_List_Test.php
@@ -36,7 +36,7 @@ class EED_Wait_List_Test extends EE_UnitTestCase
         PHPUnit_Framework_TestCase::assertEquals(
             add_query_arg(
                 array(
-                    'e_reg_url_link' => $registration->reg_url_link(),
+                    'e_reg_url_link' => $registration->get_primary_registration()->reg_url_link(),
                     'step'           => 'attendee_information',
                 ),
                 $reg_page_url


### PR DESCRIPTION
also remove debug code

Reported [here](https://eventespresso.com/topic/waitlist-for-more-than-2-people-generates-more-than-1-email-when-spot-opens/?view=all)

Ideally only one email per transaction should be triggered even if multiple registrations get promoted from the wait list, but for now we should at least send the recipient to a registration URL that will allow them to complete their registration. With the way the WL add-on works now, if you open the email for Attendee 2 (or 3, or 4) and click the link to complete the registration, you'll end up with an error like this one:
![Screen Shot 2019-08-28 at 2 20 52 PM](https://user-images.githubusercontent.com/891156/63888454-f2687280-c9ac-11e9-9a29-9dc1b5a38221.png)


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
