### PR TITLE
Argument 1 passed to EED_Recaptcha_Invisible::verifyToken() must implement interface EventEspresso\core\services\request\RequestInterface

### DIFF
--- a/domain/services/forms/WaitListFormHandler.php
+++ b/domain/services/forms/WaitListFormHandler.php
@@ -163,7 +163,7 @@ class WaitListFormHandler extends FormHandler
             return true;
         }
         return EED_Recaptcha_Invisible::verifyToken(
-            LoaderFactory::getLoader()->getShared('EE_Request')
+            LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface')
         );
     }
 }


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/wait-list-manager-error/

If you have reCaptcha enabled on your site and try to add a registration to the waitlist whilst not logged in you'll get a fatal:

```
Uncaught Error: Argument 1 passed to EED_Recaptcha_Invisible::verifyToken() must implement interface EventEspresso\core\services\request\RequestInterface, instance of EE_Request given, called in /home/pebbloco/public_html/ee4/wp-content/plugins/eea-wait-lists/domain/services/forms/WaitListFormHandler.php on line 166 in /home/pebbloco/public_html/ee4/wp-content/plugins/event-espresso-core-reg/caffeinated/modules/recaptcha_invisible/EED_Recaptcha_Invisible.module.php on line 194
verifyToken()
wp-content/plugins/eea-wait-lists/domain/services/forms/WaitListFormHandler.php:166
verifyRecaptcha()
wp-content/plugins/eea-wait-lists/domain/services/forms/WaitListFormHandler.php:118
process()
wp-content/plugins/eea-wait-lists/domain/services/event/WaitListMonitor.php:220
processWaitListFormForEvent()
wp-content/plugins/eea-wait-lists/domain/services/modules/EED_Wait_Lists.module.php:314
process_wait_list_form_for_event()
wp-content/plugins/event-espresso-core-reg/core/EE_Module_Request_Router.core.php:241
_module_router()
wp-content/plugins/event-espresso-core-reg/core/EE_Module_Request_Router.core.php:181
resolve_route()
wp-content/plugins/event-espresso-core-reg/core/EE_Front_Controller.core.php:227
pre_get_posts()
wp-includes/class-wp-hook.php:286
apply_filters()
wp-includes/class-wp-hook.php:310
do_action()
wp-includes/plugin.php:531
do_action_ref_array()
wp-includes/class-wp-query.php:1752
get_posts()
wp-includes/class-wp-query.php:3403
query()
wp-includes/class-wp.php:622
query_posts()
wp-includes/class-wp.php:739
main()
wp-includes/functions.php:1105
wp()
wp-blog-header.php:16
require()
index.php:17
```

## How has this been tested
Using release versions of EE and the Waitlist add-on enable reCaptcha on the ticket selector.

Add a waitlist registration on an event and you'll get a fatal.

Switch to this branch, refresh and repeat.

No more fatal.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
