### PR TITLE
Add 'Event Admin' context to waitlist messages

### DIFF
--- a/domain/WaitList.php
+++ b/domain/WaitList.php
@@ -13,6 +13,8 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\WaitList\domain\services\collections\WaitListEventsCollection;
 use InvalidArgumentException;
 use ReflectionException;
+use EE_Base_Class;
+use EE_Message_Template_Group;
 
 /**
  * Class  WaitListAddon
@@ -129,6 +131,12 @@ class WaitList extends EE_Addon
     {
         $this->registerDependencies();
         $this->registerCustomShortcodeLibrary();
+        add_filter(
+            'FHEE__EE_Base_Class__get_extra_meta__default_value',
+            array($this, 'setDefaultActiveStateForMessageTypes'),
+            10,
+            4
+        );
     }
 
 
@@ -273,5 +281,37 @@ class WaitList extends EE_Addon
                 }
             }
         );
+    }
+
+
+
+    /**
+     * Callback for FHEE__EE_Base_Class__get_extra_meta__default_value which is being used to ensure the default active
+     * state for our new message types is false.
+     *
+     * @param               $default
+     * @param               $meta_key
+     * @param               $single
+     * @param EE_Base_Class $model
+     * @return bool
+     * @throws EE_Error
+     */
+    public function setDefaultActiveStateForMessageTypes(
+        $default,
+        $meta_key,
+        $single,
+        EE_Base_Class $model
+    ) {
+        // only modify default for the active context meta key
+        if ($model instanceof EE_Message_Template_Group
+            && strpos($meta_key, EE_Message_Template_Group::ACTIVE_CONTEXT_RECORD_META_KEY_PREFIX . 'admin') !== false
+            && ($model->message_type() === Domain::MESSAGE_TYPE_REGISTRATION_ADDED_TO_WAIT_LIST
+                || $model->message_type() === Domain::MESSAGE_TYPE_WAIT_LIST_PROMOTION
+                || $model->message_type() === Domain::MESSAGE_TYPE_WAIT_LIST_DEMOTION
+            )
+        ) {
+            return false;
+        }
+        return $default;
     }
 }

--- a/domain/entities/EE_Registration_Added_To_Waitlist_message_type.class.php
+++ b/domain/entities/EE_Registration_Added_To_Waitlist_message_type.class.php
@@ -37,6 +37,13 @@ class EE_Registration_Added_To_Waitlist_message_type extends EE_Registration_Bas
             'description' => esc_html__('A recipient will receive the message.', 'event_espresso'),
         );
         $this->_contexts = array(
+            'admin'    => array(
+                'label'       => esc_html__('Event Admin', 'event_espresso'),
+                'description' => esc_html__(
+                    'Messages based on this template sent to the Event Administrator (event author) when users sign up to the waitlist.',
+                    'event_espresso'
+                ),
+            ),
             'attendee' => array(
                 'label'       => esc_html__('Registrant', 'event_espresso'),
                 'description' => esc_html__(

--- a/domain/entities/EE_Registration_Demoted_To_Waitlist_message_type.class.php
+++ b/domain/entities/EE_Registration_Demoted_To_Waitlist_message_type.class.php
@@ -33,6 +33,13 @@ class EE_Registration_Demoted_To_Waitlist_message_type extends EE_Waitlist_Messa
     {
         parent::_set_contexts();
         $this->_contexts = array(
+            'admin'    => array(
+                'label'       => esc_html__('Event Admin', 'event_espresso'),
+                'description' => esc_html__(
+                    'This template goes to the Event Administrator (event author) when registrations are automatically demoted to the wait list.',
+                    'event_espresso'
+                ),
+            ),
             'registrant' => array(
                 'label'       => esc_html__('Registrant', 'event_espresso'),
                 'description' => esc_html__(

--- a/domain/entities/EE_Waitlist_Can_Register_message_type.class.php
+++ b/domain/entities/EE_Waitlist_Can_Register_message_type.class.php
@@ -32,4 +32,29 @@ class EE_Waitlist_Can_Register_message_type extends EE_Waitlist_Message_Type_Bas
         );
         parent::__construct();
     }
+
+    /**
+     * _set_contexts
+     * This sets up the contexts associated with the message_type
+     */
+    public function _set_contexts()
+    {
+        parent::_set_contexts();
+        $this->_contexts = array(
+            'admin'    => array(
+                'label'       => esc_html__('Event Admin', 'event_espresso'),
+                'description' => esc_html__(
+                    'This template goes to the Event Administrator (event author) when registrations are automatically promoted to the wait list.',
+                    'event_espresso'
+                ),
+            ),
+            'registrant' => array(
+                'label'       => esc_html__('Registrant', 'event_espresso'),
+                'description' => esc_html__(
+                    'This template goes to registrations that were automatically promoted to the wait list.',
+                    'event_espresso'
+                ),
+            ),
+        );
+    }
 }

--- a/domain/entities/EE_Waitlist_Message_Type_Base.class.php
+++ b/domain/entities/EE_Waitlist_Message_Type_Base.class.php
@@ -105,6 +105,13 @@ class EE_Waitlist_Message_Type_Base extends EE_message_type
             'description' => esc_html__("Recipients are who will receive the message.", 'event_espresso'),
         );
         $this->_contexts = array(
+            'admin'    => array(
+                'label'       => esc_html__('Event Admin', 'event_espresso'),
+                'description' => esc_html__(
+                    'This template will be used to generate the message from the context of Event Administrator (event author).',
+                    'event_espresso'
+                ),
+            ),
             'registrant' => array(
                 'label'       => esc_html__('Registrant', 'event_espresso'),
                 'description' => esc_html__(

--- a/views/messages/templates/email_registration_added_to_waitlist_content_admin.template.php
+++ b/views/messages/templates/email_registration_added_to_waitlist_content_admin.template.php
@@ -1,0 +1,44 @@
+<table class="head-wrap" bgcolor="#999999">
+    <tbody>
+    <tr>
+        <td></td>
+        <td class="header container">
+            <div class="content">
+                <table bgcolor="#999999">
+                    <tbody>
+                    <tr>
+                        <td>[CO_LOGO]</td>
+                        <td align="right">
+                            <h6 class="collapse">[COMPANY]</h6>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>
+
+<table class="body-wrap">
+    <tbody>
+        <tr>
+            <td></td>
+            <td class="container" bgcolor="#FFFFFF">
+                <div class="content">
+                    <h1><?php _e('Waitlist Registration Notification', 'event_espresso'); ?></h1>
+                    <?php _e('The following attendee has registered onto the waitlist for the following event:', 'event_espresso'); ?>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[EVENT_LIST]</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/views/messages/templates/email_registration_added_to_waitlist_subject_admin.template.php
+++ b/views/messages/templates/email_registration_added_to_waitlist_subject_admin.template.php
@@ -1,0 +1,2 @@
+<?php
+_e("Waitlist Registration Details", 'event_espresso');

--- a/views/messages/templates/email_registration_demoted_to_waitlist_content_admin.template.php
+++ b/views/messages/templates/email_registration_demoted_to_waitlist_content_admin.template.php
@@ -1,0 +1,44 @@
+<table class="head-wrap" bgcolor="#999999">
+    <tbody>
+    <tr>
+        <td></td>
+        <td class="header container">
+            <div class="content">
+                <table bgcolor="#999999">
+                    <tbody>
+                    <tr>
+                        <td>[CO_LOGO]</td>
+                        <td align="right">
+                            <h6 class="collapse">[COMPANY]</h6>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>
+
+<table class="body-wrap">
+    <tbody>
+        <tr>
+            <td></td>
+            <td class="container" bgcolor="#FFFFFF">
+                <div class="content">
+                    <h1><?php _e('Waitlist Registration Demoted Notification', 'event_espresso'); ?></h1>
+                    <?php _e('The following attendee has been demoted onto the waitlist for the following event:', 'event_espresso'); ?>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[EVENT_LIST]</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/views/messages/templates/email_registration_demoted_to_waitlist_subject_admin.template.php
+++ b/views/messages/templates/email_registration_demoted_to_waitlist_subject_admin.template.php
@@ -1,0 +1,2 @@
+<?php
+_e("Demoted Waitlist Registration Details", 'event_espresso');

--- a/views/messages/templates/email_waitlist_can_register_content_admin.template.php
+++ b/views/messages/templates/email_waitlist_can_register_content_admin.template.php
@@ -1,0 +1,44 @@
+<table class="head-wrap" bgcolor="#999999">
+    <tbody>
+    <tr>
+        <td></td>
+        <td class="header container">
+            <div class="content">
+                <table bgcolor="#999999">
+                    <tbody>
+                    <tr>
+                        <td>[CO_LOGO]</td>
+                        <td align="right">
+                            <h6 class="collapse">[COMPANY]</h6>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>
+
+<table class="body-wrap">
+    <tbody>
+        <tr>
+            <td></td>
+            <td class="container" bgcolor="#FFFFFF">
+                <div class="content">
+                    <h1><?php _e('Waitlist Registration Promotion Notification', 'event_espresso'); ?></h1>
+                    <?php _e('The following registeration has been promoted from the waitlist:', 'event_espresso'); ?>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[EVENT_LIST]</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/views/messages/templates/email_waitlist_can_register_subject_admin.template.php
+++ b/views/messages/templates/email_waitlist_can_register_subject_admin.template.php
@@ -1,0 +1,2 @@
+<?php
+_e('Waitlist Registration Promoted', 'event_espresso');


### PR DESCRIPTION
This PR adds the 'Event Admin' context to waitlist messages.

To test you can use either a site that has had this add-on installed previously or a new site.

Just make sure that when you switch to this branch, the 'Event Admin' context is **deactivated** by default.

Suggestions on switching that to be enabled by default only for the 'Registration Added To Wait List Notification'? I think that's the most likely to be used but not so sure about it being enabled.

To test, set up an event with some waitlist registrations available.

I set up an event with a single free ticket which has a qty of 2 and had 100 waitlist spaces available (auto promotion enabled). I register onto the event separately with 2 registrations.

Add a normal waitlist registration and confirm the registrant context sends.

Now edit the 'Registration Added To Wait List Notification' message and enable the Event Admin context.

Repeat with another waitlist registration and confirm that both the event admin and registrant context send. (Make sure the Event Admin email makes sense)

Enabled the Event Admin context on the 'Registration Promoted From Wait List Notification'

Open up a space available on the event so that a registration is auto promoted and check the messages send and they both make sense.

Enable the event admin context on 'Registration Demoted To Wait List Notification'

Demote a registration and again confirm the messages send and make sense.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
