### PR TITLE
Use filter_var() in place of filter_input()

### DIFF
--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -321,7 +321,7 @@ class EED_Wait_Lists extends EED_Module
         }
         // Pull the HTTP_REFERER if we can
         $referer = filter_input(INPUT_SERVER, 'HTTP_REFERER');
-        if(empty($referer)) {
+        if (empty($referer)) {
             // filter_input() can return null on some setups, so fall back to filter_var() in that case.
             $referer = filter_var($_SERVER['HTTP_REFERER'], FILTER_UNSAFE_RAW, FILTER_NULL_ON_FAILURE);
         }

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -323,7 +323,7 @@ class EED_Wait_Lists extends EED_Module
             add_query_arg(
                 $redirect_params,
                 trailingslashit(
-                    filter_input(INPUT_SERVER, 'HTTP_REFERER')
+                    filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_STRING )
                 )
             )
         );

--- a/domain/services/modules/EED_Wait_Lists.module.php
+++ b/domain/services/modules/EED_Wait_Lists.module.php
@@ -319,12 +319,22 @@ class EED_Wait_Lists extends EED_Module
         if (defined('DOING_AJAX') && DOING_AJAX) {
             exit();
         }
+        // Pull the HTTP_REFERER if we can
+        $referer = filter_input(INPUT_SERVER, 'HTTP_REFERER');
+        if(empty($referer)) {
+            // filter_input() can return null on some setups, so fall back to filter_var() in that case.
+            $referer = filter_var($_SERVER['HTTP_REFERER'], FILTER_UNSAFE_RAW, FILTER_NULL_ON_FAILURE);
+        }
+        // Filter the redirect_url.
+        $redirect_url = apply_filters(
+            'FHEE__EED_Wait_Lists__process_wait_list_form_for_event__redirect_url',
+            $referer,
+            $redirect_params
+        );
         EEH_URL::safeRedirectAndExit(
             add_query_arg(
                 $redirect_params,
-                trailingslashit(
-                    filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_STRING )
-                )
+                trailingslashit($redirect_url)
             )
         );
     }


### PR DESCRIPTION
This branch just swaps out filter_var() in place of filter_input() as apparently it can return null on some setups.

Reported here: https://eventespresso.com/topic/observations-and-questions-about-the-wait-list-manager-addon/

For another report, see: https://github.com/xwp/stream/issues/254 

## How has this been tested
Confirm that the waitlist add-on redirects you back to the same event/page that you submitted the form on and not back to home.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
