### PR TITLE
Add html classname to qty input, resolves #25

### DIFF
--- a/domain/services/forms/WaitListForm.php
+++ b/domain/services/forms/WaitListForm.php
@@ -261,6 +261,7 @@ class WaitListForm extends EE_Form_Section_Proper
                             array(
                                 'html_label_text'  => esc_html__('Qty', 'event_espresso'),
                                 'html_label_class' => 'small-text grey-text',
+                                'html_class'       => 'wait-list-qty',
                                 'html_style'       => 'max-width:120px;',
                                 'default'          => 1,
                                 'required'         => true,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #25 
## How has this been tested
Not much to test, other than load up a sold out event page and make sure the page renders. You could  also verify using an HTML inspector/view source to see the new class name added to the quantity input & its div wrapper.
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
