### PR TITLE
Disable the waitlist form submit button once the form has been submitted 

### DIFF
--- a/assets/wait_list.js
+++ b/assets/wait_list.js
@@ -57,6 +57,10 @@ jQuery(document).ready(function($) {
         $inputs.each(function() {
             valid_ticket_selection($(this), event);
         });
+        // once submitted, disable the submit button
+        $(this).parents('form:first').one('submit', function() {
+            $('input.ee-submit-wait-list-btn').prop('disabled', true);
+        });
     });
 
     var valid_ticket_selection = function($selector, event) {


### PR DESCRIPTION
If you submit a registration to the waitlist form, the button currently remains clickable and if the user is impatient they can submit multiple waitlist registrations by clicking the button multiple times.

To reproduce, I set up an event with 100 waitlist registration spaces and 0 ticket qty so that it is instantly sold out.

Like so: https://monosnap.com/file/9sh32IA6NuHcv7qusVnJjF5EwY5Udf

Waitlist: https://monosnap.com/file/az9cJLNexIcAnJXC7RMEY2LyaUckVV

Add a registration to the waitlist and mash the submit button a few times when you submit. You'll get a waitlist registration created for each time you clicked.

----

Switch to this branch, hard refresh the event page so you get the latest js file.

Now add another registration to the waitlist.... the submit button should be disabled as soon as you click it, mash it and confirm you only get 1 waitlist registration.

Also test the form field validation,  submit with no name for example, the submit button should NOT disable unless the form actually submits, in which case you'll be redirected/refresh anyway.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
